### PR TITLE
feat: send traces to a collector using the otlp and grpc 

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -96,4 +96,4 @@ jobs:
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3
         with:
-          fail_ci_if_error: true
+          fail_ci_if_error: false

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@v37.0.5
+        uses: tj-actions/changed-files@v37.4.0
 
   run_unitary_tests:
     name: Run clippy and unitary tests

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ reool = { version = "0.30.0", optional = true }
 serde = "1.0.164" # data parser
 serde_json = "1.0.96"
 sha256 = "1.1.4"
-sqlx = { version = "0.6.3", features = [
+sqlx = { version = "0.7.1", features = [
     "runtime-tokio-rustls",
     "postgres",
     "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,10 +24,7 @@ opentelemetry_api = { version = "0.19.0", features = [
 opentelemetry_sdk = { version = "0.19.0", features = [
     "rt-tokio",
 ], optional = true }
-opentelemetry-otlp = { version = "0.12.0", features = [
-    "tonic",
-    "metrics",
-], optional = true }
+opentelemetry-otlp = { version = "0.12.0", optional = true }
 opentelemetry-semantic-conventions = { version = "0.11.0", optional = true }
 prost = { version = "0.11.9", optional = true } # protobuf
 protoc = { version = "2.28.0", optional = true }
@@ -47,7 +44,7 @@ strum = "0.25.0"
 strum_macros = "0.25.0"
 tera = "1.19.0" # template engine
 tokio = { version = "1.28.2", features = ["macros", "rt", "rt-multi-thread"] }
-tonic = { version = "0.8.3", optional = true } # gRPC - OUTDATED! follows tonic version from opentelemetry-otlp 
+tonic = { version = "0.9", optional = true } # gRPC
 tracing = { version = "0.1.37" }
 tracing-subscriber = { version = "0.3.17", optional = true }
 tracing-opentelemetry = { version = "0.19.0", optional = true }
@@ -60,13 +57,22 @@ name = "rauth"
 path = "src/lib.rs"
 
 [features]
-default = ["config", "grpc", "rest", "postgres", "rabbitmq", "redis-cache"]
+default = ["grpc", "rest", "postgres", "rabbitmq", "redis-cache"]
 config = []
 grpc = ["prost", "protoc", "tonic"]
+grpc-service = [
+    "grpc",
+    "postgres",
+    "redis-cache",
+    "rabbitmq",
+    "config",
+    "trace",
+]
 postgres = ["sqlx"]
 rabbitmq = ["deadpool-lapin", "lapin"]
 redis-cache = ["redis", "reool"]
 rest = ["actix-web"]
+rest-service = ["rest", "config", "trace"]
 trace = [
     "tracing-subscriber",
     "tracing-opentelemetry",
@@ -79,9 +85,9 @@ trace = [
 [[bin]]
 name = "grpc"
 path = "src/bin/grpc.rs"
-required-features = ["grpc", "trace"]
+required-features = ["grpc-service"]
 
 [[bin]]
 name = "rest"
 path = "src/bin/rest.rs"
-required-features = ["rest", "trace"]
+required-features = ["rest-service"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,15 +55,7 @@ name = "rauth"
 path = "src/lib.rs"
 
 [features]
-default = [
-    "grpc",
-    "rest",
-    "postgres",
-    "rabbitmq",
-    "redis-cache",
-    "grpc-service",
-    "rest-service",
-]
+default = ["grpc-service", "rest-service"]
 config = []
 grpc = ["prost", "protoc", "tonic"]
 grpc-service = [
@@ -77,9 +69,10 @@ grpc-service = [
 postgres = ["sqlx"]
 rabbitmq = ["deadpool-lapin", "lapin"]
 redis-cache = ["redis", "reool"]
-rest = ["actix-web"]
+rest = ["actix-web", "redis-cache"]
 rest-service = ["rest", "config", "trace"]
 trace = [
+    "tonic",
     "tracing-subscriber",
     "tracing-opentelemetry",
     "opentelemetry_api",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ dotenv = "0.15.0"
 futures = "0.3.28"
 jsonwebtoken = "8.3.0"
 lapin = { version = "2.2.1", optional = true }
-lettre = "0.10.4"
+lettre = { version = "0.10.4", optional = true }
 libreauth = "0.16.0"
 once_cell = "1.18.0"
 openssl = "0.10.54"
@@ -40,10 +40,10 @@ sqlx = { version = "0.7.1", features = [
 ], optional = true }
 strum = "0.25.0"
 strum_macros = "0.25.0"
-tera = "1.19.0" # template engine
+tera = { version = "1.19.0", optional = true } # template engine
 tokio = { version = "1.28.2", features = ["macros", "rt", "rt-multi-thread"] }
 tonic = { version = "0.9", optional = true } # gRPC
-tracing = { version = "0.1.37" }
+tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.17", optional = true }
 tracing-opentelemetry = { version = "0.20.0", optional = true }
 
@@ -56,22 +56,15 @@ path = "src/lib.rs"
 
 [features]
 default = ["grpc-service", "rest-service"]
-config = []
 grpc = ["prost", "protoc", "tonic"]
-grpc-service = [
-    "grpc",
-    "postgres",
-    "redis-cache",
-    "rabbitmq",
-    "config",
-    "trace",
-]
+grpc-service = ["grpc", "postgres", "redis-cache", "rabbitmq", "smtp", "tracer"]
 postgres = ["sqlx"]
 rabbitmq = ["deadpool-lapin", "lapin"]
 redis-cache = ["redis", "reool"]
 rest = ["actix-web", "redis-cache"]
-rest-service = ["rest", "config", "trace"]
-trace = [
+rest-service = ["rest", "tracer"]
+smtp = ["lettre", "tera"]
+tracer = [
     "tonic",
     "tracing-subscriber",
     "tracing-opentelemetry",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ opentelemetry_sdk = { version = "0.20.0", features = [
     "rt-tokio",
 ], optional = true }
 opentelemetry-otlp = { version = "0.13.0", optional = true }
-opentelemetry-semantic-conventions = { version = "0.11.0", optional = true }
+opentelemetry-semantic-conventions = { version = "0.12.0", optional = true }
 prost = { version = "0.11.9", optional = true } # protobuf
 protoc = { version = "2.28.0", optional = true }
 rand = "0.8.5"
@@ -45,7 +45,7 @@ tokio = { version = "1.28.2", features = ["macros", "rt", "rt-multi-thread"] }
 tonic = { version = "0.9", optional = true } # gRPC
 tracing = { version = "0.1.37" }
 tracing-subscriber = { version = "0.3.17", optional = true }
-tracing-opentelemetry = { version = "0.19.0", optional = true }
+tracing-opentelemetry = { version = "0.20.0", optional = true }
 
 [build-dependencies]
 tonic-build = "0.9.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,12 +56,10 @@ path = "src/lib.rs"
 
 [features]
 grpc = ["prost", "protoc", "tonic"]
-grpc-service = ["grpc", "postgres", "redis-cache", "rabbitmq", "smtp", "tracer"]
 postgres = ["sqlx"]
 rabbitmq = ["deadpool-lapin", "lapin"]
 redis-cache = ["redis", "reool"]
 rest = ["actix-web", "redis-cache"]
-rest-service = ["rest", "tracer"]
 smtp = ["lettre", "tera"]
 tracer = [
     "tonic",
@@ -76,9 +74,9 @@ tracer = [
 [[bin]]
 name = "grpc"
 path = "src/bin/grpc.rs"
-required-features = ["grpc-service"]
+required-features = ["postgres", "redis-cache", "rabbitmq", "smtp", "tracer"]
 
 [[bin]]
 name = "rest"
 path = "src/bin/rest.rs"
-required-features = ["rest-service"]
+required-features = ["rest", "tracer"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,13 +18,11 @@ lettre = "0.10.4"
 libreauth = "0.16.0"
 once_cell = "1.18.0"
 openssl = "0.10.54"
-opentelemetry_api = { version = "0.19.0", features = [
-    "metrics",
-], optional = true }
-opentelemetry_sdk = { version = "0.19.0", features = [
+opentelemetry_api = { version = "0.20.0", features = [], optional = true }
+opentelemetry_sdk = { version = "0.20.0", features = [
     "rt-tokio",
 ], optional = true }
-opentelemetry-otlp = { version = "0.12.0", optional = true }
+opentelemetry-otlp = { version = "0.13.0", optional = true }
 opentelemetry-semantic-conventions = { version = "0.11.0", optional = true }
 prost = { version = "0.11.9", optional = true } # protobuf
 protoc = { version = "2.28.0", optional = true }
@@ -57,7 +55,15 @@ name = "rauth"
 path = "src/lib.rs"
 
 [features]
-default = ["grpc", "rest", "postgres", "rabbitmq", "redis-cache"]
+default = [
+    "grpc",
+    "rest",
+    "postgres",
+    "rabbitmq",
+    "redis-cache",
+    "grpc-service",
+    "rest-service",
+]
 config = []
 grpc = ["prost", "protoc", "tonic"]
 grpc-service = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,6 @@ name = "rauth"
 path = "src/lib.rs"
 
 [features]
-default = ["grpc-service", "rest-service"]
 grpc = ["prost", "protoc", "tonic"]
 grpc-service = ["grpc", "postgres", "redis-cache", "rabbitmq", "smtp", "tracer"]
 postgres = ["sqlx"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,19 +6,29 @@ edition = "2021"
 
 [dependencies]
 actix-web = { version = "4.3.1", optional = true } # rest
-async_once = "0.2.6"
 async-trait = "0.1.68"
 base64 = "0.21.2"
 chrono = "0.4.26"
 deadpool-lapin = { version = "0.10.0", optional = true }
 dotenv = "0.15.0"
+futures = "0.3.28"
 jsonwebtoken = "8.3.0"
 lapin = { version = "2.2.1", optional = true }
-lazy_static = "1.4.0"
 lettre = "0.10.4"
 libreauth = "0.16.0"
 once_cell = "1.18.0"
 openssl = "0.10.54"
+opentelemetry_api = { version = "0.19.0", features = [
+    "metrics",
+], optional = true }
+opentelemetry_sdk = { version = "0.19.0", features = [
+    "rt-tokio",
+], optional = true }
+opentelemetry-otlp = { version = "0.12.0", features = [
+    "tonic",
+    "metrics",
+], optional = true }
+opentelemetry-semantic-conventions = { version = "0.11.0", optional = true }
 prost = { version = "0.11.9", optional = true } # protobuf
 protoc = { version = "2.28.0", optional = true }
 rand = "0.8.5"
@@ -37,9 +47,10 @@ strum = "0.25.0"
 strum_macros = "0.25.0"
 tera = "1.19.0" # template engine
 tokio = { version = "1.28.2", features = ["macros", "rt", "rt-multi-thread"] }
-tonic = { version = "0.9.2", optional = true } # gRPC
-tracing = "0.1"
-tracing-subscriber = "0.3"
+tonic = { version = "0.8.3", optional = true } # gRPC - OUTDATED! follows tonic version from opentelemetry-otlp 
+tracing = { version = "0.1.37" }
+tracing-subscriber = { version = "0.3.17", optional = true }
+tracing-opentelemetry = { version = "0.19.0", optional = true }
 
 [build-dependencies]
 tonic-build = "0.9.2"
@@ -56,13 +67,21 @@ postgres = ["sqlx"]
 rabbitmq = ["deadpool-lapin", "lapin"]
 redis-cache = ["redis", "reool"]
 rest = ["actix-web"]
+trace = [
+    "tracing-subscriber",
+    "tracing-opentelemetry",
+    "opentelemetry_api",
+    "opentelemetry_sdk",
+    "opentelemetry-otlp",
+    "opentelemetry-semantic-conventions",
+]
 
 [[bin]]
 name = "grpc"
 path = "src/bin/grpc.rs"
-required-features = ["grpc"]
+required-features = ["grpc", "trace"]
 
 [[bin]]
 name = "rest"
 path = "src/bin/rest.rs"
-required-features = ["rest"]
+required-features = ["rest", "trace"]

--- a/Makefile
+++ b/Makefile
@@ -6,10 +6,10 @@ all: binaries
 
 binaries: install-deps
 ifdef target
-	cargo build --bin $(target) --no-default-features --features $(target) --release
+	cargo build --bin $(target) --no-default-features --features $(target),trace --release
 else
-	-cargo build --bin grpc --no-default-features --features grpc --release
-	-cargo build --bin rest --no-default-features --features rest --release
+	-cargo build --bin grpc --no-default-features --features grpc,trace --release
+	-cargo build --bin rest --no-default-features --features rest,trace --release
 endif
 
 images:

--- a/Makefile
+++ b/Makefile
@@ -6,10 +6,10 @@ all: binaries
 
 binaries: install-deps
 ifdef target
-	cargo build --bin $(target) --no-default-features --features $(target),trace --release
+	cargo build --bin $(target) --no-default-features --features $(target)-service --release
 else
-	-cargo build --bin grpc --no-default-features --features grpc,trace --release
-	-cargo build --bin rest --no-default-features --features rest,trace --release
+	-cargo build --bin grpc --no-default-features --features grpc-service --release
+	-cargo build --bin rest --no-default-features --features rest-service --release
 endif
 
 images:

--- a/Makefile
+++ b/Makefile
@@ -2,14 +2,17 @@ BINARY_NAME=rauth
 VERSION?=latest
 PKG_MANAGER?=dnf
 
+features_grpc="grpc postgres redis-cache rabbitmq smtp tracer"
+features_rest="rest tracer"
+
 all: binaries
 
 binaries: install-deps
 ifdef target
-	cargo build --bin $(target) --no-default-features --features $(target)-service --release
+	cargo build --bin $(target) --features=$(features_$(target)) --release
 else
-	-cargo build --bin grpc --no-default-features --features grpc-service --release
-	-cargo build --bin rest --no-default-features --features rest-service --release
+	-cargo build --bin grpc --features=$(features_grpc) --release
+	-cargo build --bin rest --features=$(features_rest) --release
 endif
 
 images:

--- a/README.md
+++ b/README.md
@@ -268,8 +268,8 @@ The server expects a set of environment variables to work properly. Although som
 
 | Environment variable    |           Default value           | Description                                                                                                                                          |
 | :---------------------- | :-------------------------------: | :--------------------------------------------------------------------------------------------------------------------------------------------------- |
-| SERVICE_PORT            |               8000                | Port where to expose the service service                                                                                                                |
-| SERVICE_ADDR            |             127.0.0.1             | Address where to expose the service service                                                                                                             |
+| SERVICE_PORT            |               8000                | Port where to expose the service service                                                                                                             |
+| SERVICE_ADDR            |             127.0.0.1             | Address where to expose the service service                                                                                                          |
 | POSTGRES_DSN            |                                   | `Postgres` data source name                                                                                                                          |
 | POSTGRES_POOL           |                10                 | `Postgres` connection pool size                                                                                                                      |
 | REDIS_URL               |                                   | `Redis` URL                                                                                                                                          |
@@ -282,7 +282,7 @@ The server expects a set of environment variables to work properly. Although som
 | SMTP_ISSUER             |               rauth               | Name to identify where the emails are sent from                                                                                                      |
 | SMTP_ORIGIN             |                                   | Email to set as the `from` for all sent emails                                                                                                       |
 | SMTP_TRANSPORT          |                                   | Smtp transporter URL (ex.: smtp.gmail.com)                                                                                                           |
-| SMTP_TEMPLATES          | /etc/rauth/smtp/templates/\*.html | Path where to find all email's templates                                                                                                             |
+| SMTP_TEMPLATES          | /etc/rauth/smtp/templates/\*.html | Path where to find all email templates                                                                                                               |
 | SMTP_USERNAME           |                                   | If required, a username to enable the application to send emails                                                                                     |
 | SMTP_PASSWORD           |                                   | If required, an application password to enable the application to send emails                                                                        |
 | PWD_SUFIX               |           ::PWD::RAUTH            | A suffix to append to all passwords before hashing and storing them                                                                                  |
@@ -290,9 +290,10 @@ The server expects a set of environment variables to work properly. Although som
 | RABBITMQ_URL            |                                   | `RabbitMQ` URL                                                                                                                                       |
 | RABBITMQ_POOL           |                10                 | `RabbitMQ` connection pool size                                                                                                                      |
 | EVENT_ISSUER            |                                   | Issuer name for all emited events                                                                                                                    |
-| TOTP_SECRET_LEN         |                                   | Length of the random generated secret to be used for the TOTP                                                                                        |
-| TOTP_SECRET_NAME        |                                   | Name by which every TOTP secret will be stored in the database                                                                                       |
+| TOTP_SECRET_LEN         |                32                 | Bytes of the random generated secret to be used for the Time-based One Time Password                                                                 |
 | TOKEN_ISSUER            |                                   | Issuer value for the `iss` field of any generated token                                                                                              |
+| SERVICE_NAME            |               rauth               | Service identification to be emited with every trace                                                                                                 |
+| COLLECTOR_URL           |                                   | Url of the collector where to send all the traces using the [Opentelemetry Protocol](https://opentelemetry.io/docs/specs/otel/protocol/)             |
 
 > All these environment variables can be set in a .env file, since Rauth uses dotenv to set up the environment
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -29,6 +29,15 @@ services:
     security_opt:
       label: disable
 
+  mailhog:
+    container_name: rauth-mailhog
+    image: docker.io/mailhog/mailhog:v1.0.1
+    restart: always
+    ports:
+      - 8025:8025
+    security_opt:
+      label: disable
+
   grpc:
     container_name: rauth-grpc
     image: localhost/alvidir/rauth:latest-grpc
@@ -48,44 +57,35 @@ services:
     environment:
       - SERVICE_PORT=8000
 
-  rest:
-    container_name: rauth-rest
-    image: localhost/alvidir/rauth:latest-rest
-    restart: always
-    ports:
-      - 8001:8001
-    security_opt:
-      label: disable
-    depends_on:
-      - redis
-    env_file:
-      - .env
-    environment:
-      - SERVICE_PORT=8001
+  # envoy:
+  #   container_name: rauth-envoy
+  #   image: docker.io/envoyproxy/envoy-alpine:v1.21-latest
+  #   restart: always
+  #   ports:
+  #     - 8080:8080
+  #     - 9901:9901
+  #   volumes:
+  #     - ./envoy:/etc/envoy:ro
+  #   security_opt:
+  #     label: disable
+  #   depends_on:
+  #     - grpc
+  #   command: /usr/local/bin/envoy --log-level debug -c /etc/envoy/envoy.yaml
 
-  envoy:
-    container_name: rauth-envoy
-    image: docker.io/envoyproxy/envoy-alpine:v1.21-latest
-    restart: always
-    ports:
-      - 8080:8080
-      - 9901:9901
-    volumes:
-      - ./envoy:/etc/envoy:ro
-    security_opt:
-      label: disable
-    depends_on:
-      - grpc
-    command: /usr/local/bin/envoy --log-level debug -c /etc/envoy/envoy.yaml
-
-  mailhog:
-    container_name: mailhog
-    image: docker.io/mailhog/mailhog:v1.0.1
-    restart: always
-    ports:
-      - 8025:8025
-    security_opt:
-      label: disable
+  # rest:
+  #   container_name: rauth-rest
+  #   image: localhost/alvidir/rauth:latest-rest
+  #   restart: always
+  #   ports:
+  #     - 8001:8001
+  #   security_opt:
+  #     label: disable
+  #   depends_on:
+  #     - redis
+  #   env_file:
+  #     - .env
+  #   environment:
+  #     - SERVICE_PORT=8001
 
 volumes:
   dbdata:

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,7 +1,7 @@
 services:
   postgres:
     container_name: rauth-postgres
-    image: docker.io/postgres:alpine3.17
+    image: docker.io/postgres:alpine3.18
     restart: on-failure
     volumes:
       - dbdata:/data/postgres
@@ -13,7 +13,7 @@ services:
 
   redis:
     container_name: rauth-redis
-    image: docker.io/redis:alpine3.17
+    image: docker.io/redis:alpine3.18
     restart: always
     volumes:
       - ./redis:/usr/local/etc/redis:ro

--- a/compose.yaml
+++ b/compose.yaml
@@ -87,5 +87,18 @@ services:
   #   environment:
   #     - SERVICE_PORT=8001
 
+  jaeger:
+    container_name: rauth-jaeger
+    image: docker.io/jaegertracing/all-in-one:latest
+    restart: always
+    ports:
+      - 16686:16686
+      - 4317:4317
+      - 4318:4318
+    security_opt:
+      label: disable
+    environment:
+      - COLLECTOR_OTLP_ENABLED=true
+
 volumes:
   dbdata:

--- a/container/grpc/containerfile
+++ b/container/grpc/containerfile
@@ -14,7 +14,7 @@ ADD . .
 RUN PKG_MANAGER=apt-get make all target=grpc
 
 ######## Start a new stage from scratch #######
-FROM docker.io/debian:stable-slim
+FROM docker.io/debian:bullseye-slim
 ARG APP=/usr/src/app
 
 RUN apt-get update \

--- a/container/grpc/containerfile
+++ b/container/grpc/containerfile
@@ -1,4 +1,4 @@
-FROM docker.io/rust:1.70.0 as builder
+FROM docker.io/rust:1.71.0 as builder
 
 RUN apt-get update && \
     apt-get install -y software-properties-common && \
@@ -8,7 +8,7 @@ RUN apt-get update && \
     apt-get upgrade -y
 
 WORKDIR /app
-RUN rustup component add rustfmt --toolchain 1.70.0-x86_64-unknown-linux-gnu
+RUN rustup component add rustfmt --toolchain 1.71.0-x86_64-unknown-linux-gnu
 
 ADD . .
 RUN PKG_MANAGER=apt-get make all target=grpc

--- a/container/rest/containerfile
+++ b/container/rest/containerfile
@@ -1,4 +1,4 @@
-FROM docker.io/rust:1.70.0 as builder
+FROM docker.io/rust:1.71.0 as builder
 
 RUN USER=root cargo new --bin rauth
 RUN apt-get update && \
@@ -8,7 +8,7 @@ RUN apt-get update && \
     apt-get upgrade -y
 
 WORKDIR /app
-RUN rustup component add rustfmt --toolchain 1.70.0-x86_64-unknown-linux-gnu
+RUN rustup component add rustfmt --toolchain 1.71.0-x86_64-unknown-linux-gnu
 
 ADD . .
 RUN PKG_MANAGER=apt-get make all target=rest

--- a/container/rest/containerfile
+++ b/container/rest/containerfile
@@ -14,7 +14,7 @@ ADD . .
 RUN PKG_MANAGER=apt-get make all target=rest
 
 ######## Start a new stage from scratch #######
-FROM docker.io/debian:stable-slim
+FROM docker.io/debian:bullseye-slim
 ARG APP=/usr/src/app
 
 RUN apt-get update \

--- a/migrations/2022-01-06-164702_create_metadata/down.sql
+++ b/migrations/2022-01-06-164702_create_metadata/down.sql
@@ -1,2 +1,3 @@
 -- This file should undo anything in `up.sql`
+DROP FUNCTION fn_update_metadata;
 DROP TABLE Metadata;

--- a/migrations/2022-01-06-164702_create_metadata/up.sql
+++ b/migrations/2022-01-06-164702_create_metadata/up.sql
@@ -5,3 +5,17 @@ CREATE TABLE Metadata (
     updated_at TIMESTAMP NOT NULL DEFAULT NOW(),
     deleted_at TIMESTAMP
 );
+
+CREATE OR REPLACE FUNCTION fn_update_metadata()
+    RETURNS trigger AS
+$BODY$
+    BEGIN
+        UPDATE Metadata
+        SET
+            updated_at = NOW(),
+        WHERE
+            id = NEW.meta_id;
+    END;
+$BODY$
+    LANGUAGE plpgsql VOLATILE
+    COST 100;

--- a/migrations/2022-01-06-164754_create_user/down.sql
+++ b/migrations/2022-01-06-164754_create_user/down.sql
@@ -1,2 +1,3 @@
 -- This file should undo anything in `up.sql`
+DROP TRIGGER trg_update_metadata_once_user_updated ON TABLE Users;
 DROP TABLE Users;

--- a/migrations/2022-01-06-164754_create_user/up.sql
+++ b/migrations/2022-01-06-164754_create_user/up.sql
@@ -10,3 +10,9 @@ CREATE TABLE Users (
     FOREIGN KEY (meta_id)
         REFERENCES Metadata(id)
 );
+
+CREATE TRIGGER trg_update_metadata_once_user_updated
+    AFTER UPDATE OF *
+    ON Users
+    FOR EACH ROW
+    EXECUTE PROCEDURE fn_update_metadata;

--- a/migrations/2022-01-06-164779_create_secret/down.sql
+++ b/migrations/2022-01-06-164779_create_secret/down.sql
@@ -1,2 +1,5 @@
 -- This file should undo anything in `up.sql`
+DROP TYPE SECRET;
+DROP TRIGGER trg_prevent_update_secrets_data ON TABLE Secrets;
+DROP FUNCTION fn_prevent_update_secrets_data;
 DROP TABLE Secrets;

--- a/migrations/2022-01-06-164779_create_secret/up.sql
+++ b/migrations/2022-01-06-164779_create_secret/up.sql
@@ -1,12 +1,14 @@
 -- Your SQL goes here
+CREATE TYPE SECRET AS ENUM ('totp');
+
 CREATE TABLE Secrets (
     id SERIAL PRIMARY KEY,
-    name VARCHAR(64) NOT NULL,
+    type SECRET NOT NULL,
     data TEXT NOT NULL,
     user_id INTEGER NOT NULL,
     meta_id INTEGER NOT NULL UNIQUE,
 
-    UNIQUE (name, user_id),
+    UNIQUE (type, user_id),
 
     FOREIGN KEY (user_id)
         REFERENCES Users(id),
@@ -18,14 +20,14 @@ CREATE OR REPLACE FUNCTION fn_prevent_update_secrets_data()
     RETURNS trigger AS
 $BODY$
     BEGIN
-        RAISE EXCEPTION 'cannot update immutable field';
+        RAISE EXCEPTION 'cannot update secret fields';
     END;
 $BODY$
     LANGUAGE plpgsql VOLATILE
     COST 100;
 
 CREATE TRIGGER trg_prevent_update_secrets_data
-    BEFORE UPDATE OF id, name, data, user_id
+    BEFORE UPDATE OF *
     ON Secrets
     FOR EACH ROW
-    EXECUTE PROCEDURE fn_prevent_update_secrets_data();
+    EXECUTE PROCEDURE fn_prevent_update_secrets_data;

--- a/src/bin/grpc.rs
+++ b/src/bin/grpc.rs
@@ -4,13 +4,16 @@ extern crate tracing;
 use rauth::{
     config,
     metadata::repository::PostgresMetadataRepository,
+    postgres, rabbitmq, redis,
     secret::repository::PostgresSecretRepository,
     session::{
         application::SessionApplication,
         grpc::{SessionGrpcService, SessionServer},
     },
-    smtp::Smtp,
+    smtp,
+    smtp::SmtpBuilder,
     token::{application::TokenApplication, repository::RedisTokenRepository},
+    tracer,
     user::{
         application::UserApplication,
         event_bus::RabbitMqUserBus,
@@ -29,47 +32,42 @@ async fn main() -> Result<(), Box<dyn Error>> {
         warn!(error = err.to_string(), "processing dotenv file");
     }
 
-    config::init_global_tracer()?;
+    tracer::init()?;
 
     let metadata_repo = Arc::new(PostgresMetadataRepository {
-        pool: &config::POSTGRES_POOL,
+        pool: &postgres::POSTGRES_POOL,
     });
 
     let secret_repo = Arc::new(PostgresSecretRepository {
-        pool: &config::POSTGRES_POOL,
+        pool: &postgres::POSTGRES_POOL,
         metadata_repo: metadata_repo.clone(),
     });
 
     let user_repo = Arc::new(PostgresUserRepository {
-        pool: &config::POSTGRES_POOL,
+        pool: &postgres::POSTGRES_POOL,
         metadata_repo: metadata_repo.clone(),
     });
 
     let user_event_bus = Arc::new(RabbitMqUserBus {
-        pool: &config::RABBITMQ_POOL,
-        exchange: &config::RABBITMQ_USERS_EXCHANGE,
-        issuer: &config::EVENT_ISSUER,
+        pool: &rabbitmq::RABBITMQ_POOL,
+        exchange: &rabbitmq::RABBITMQ_USERS_EXCHANGE,
+        issuer: &rabbitmq::EVENT_ISSUER,
     });
 
     let token_repo = Arc::new(RedisTokenRepository {
-        pool: &config::REDIS_POOL,
+        pool: &redis::REDIS_POOL,
     });
-    let credentials = if config::SMTP_USERNAME.len() > 0 && config::SMTP_PASSWORD.len() > 0 {
-        Some((
-            config::SMTP_USERNAME.to_string(),
-            config::SMTP_PASSWORD.to_string(),
-        ))
-    } else {
-        None
-    };
 
-    let mailer = Smtp::new(
-        &config::SMTP_ORIGIN,
-        &config::SMTP_TEMPLATES,
-        &config::SMTP_TRANSPORT,
-        credentials,
-    )?
-    .with_issuer(&config::SMTP_ISSUER);
+    let smtp = SmtpBuilder {
+        issuer: &smtp::SMTP_ISSUER,
+        origin: &smtp::SMTP_ORIGIN,
+        templates: &smtp::SMTP_TEMPLATES,
+        transport: &smtp::SMTP_TRANSPORT,
+        username: &smtp::SMTP_USERNAME,
+        password: &smtp::SMTP_PASSWORD,
+        ..Default::default()
+    }
+    .build()?;
 
     let token_app = Arc::new(TokenApplication {
         token_repo: token_repo.clone(),
@@ -83,7 +81,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         user_repo: user_repo.clone(),
         secret_repo: secret_repo.clone(),
         token_app: token_app.clone(),
-        mailer: Arc::new(mailer),
+        mailer: Arc::new(smtp),
         event_bus: user_event_bus.clone(),
         totp_secret_len: *config::TOTP_SECRET_LEN,
         pwd_sufix: &config::PWD_SUFIX,
@@ -119,6 +117,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .serve(addr)
         .await?;
 
-    config::shutdown_global_tracer();
+    tracer::shutdown();
     Ok(())
 }

--- a/src/bin/rest.rs
+++ b/src/bin/rest.rs
@@ -4,9 +4,10 @@ extern crate tracing;
 use actix_web::web::Data;
 use actix_web::{middleware, App, HttpServer};
 use rauth::{
-    config,
+    config, redis,
     session::rest::SessionRestService,
     token::{application::TokenApplication, repository::RedisTokenRepository},
+    tracer,
 };
 use std::error::Error;
 use std::sync::Arc;
@@ -18,10 +19,10 @@ async fn main() -> Result<(), Box<dyn Error>> {
         warn!(error = err.to_string(), "processing dotenv file",);
     }
 
-    config::init_global_tracer()?;
+    tracer::init()?;
 
     let token_repo = Arc::new(RedisTokenRepository {
-        pool: &config::REDIS_POOL,
+        pool: &redis::REDIS_POOL,
     });
 
     let token_app = TokenApplication {
@@ -53,6 +54,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
     .await
     .unwrap();
 
-    config::shutdown_global_tracer();
+    tracer::shutdown();
     Ok(())
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -66,3 +66,63 @@ pub static TOTP_SECRET_LEN: Lazy<usize> = Lazy::new(|| {
 
 pub static TOKEN_ISSUER: Lazy<String> =
     Lazy::new(|| env::var(ENV_TOKEN_ISSUER).expect("token issuer must be set"));
+
+#[cfg(test)]
+mod tests {
+    use crate::config::{
+        DEFAULT_ADDR, DEFAULT_JWT_HEADER, DEFAULT_PORT, DEFAULT_TOKEN_TIMEOUT, DEFAULT_TOTP_HEADER,
+        DEFAULT_TOTP_SECRET_LEN, JWT_HEADER, PWD_SUFIX, SERVICE_ADDR, TOKEN_ISSUER, TOKEN_TIMEOUT,
+        TOTP_HEADER, TOTP_SECRET_LEN,
+    };
+
+    use super::{JWT_PUBLIC, JWT_SECRET};
+
+    #[test]
+    fn default_service_addr_must_not_fail() {
+        assert_eq!(*SERVICE_ADDR, format!("{DEFAULT_ADDR}:{DEFAULT_PORT}"));
+    }
+
+    #[test]
+    fn default_token_timeout_must_not_fail() {
+        assert_eq!(*TOKEN_TIMEOUT, DEFAULT_TOKEN_TIMEOUT);
+    }
+
+    #[test]
+    #[should_panic]
+    fn default_jwt_secret_must_fail() {
+        let _ = &*JWT_SECRET;
+    }
+
+    #[test]
+    #[should_panic]
+    fn default_jwt_public_must_fail() {
+        let _ = &*JWT_PUBLIC;
+    }
+
+    #[test]
+    fn default_jwt_header_must_not_fail() {
+        assert_eq!(*JWT_HEADER, DEFAULT_JWT_HEADER);
+    }
+
+    #[test]
+    fn default_totp_header_must_not_fail() {
+        assert_eq!(*TOTP_HEADER, DEFAULT_TOTP_HEADER);
+    }
+
+    #[test]
+    #[should_panic]
+    fn default_pwd_sufix_must_fail() {
+        let _ = &*PWD_SUFIX;
+    }
+
+    #[test]
+    fn default_totp_secret_len_must_not_fail() {
+        assert_eq!(*TOTP_SECRET_LEN, DEFAULT_TOTP_SECRET_LEN);
+    }
+
+    #[test]
+    #[should_panic]
+    fn default_token_issuer_must_fail() {
+        let _ = &*TOKEN_ISSUER;
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -222,7 +222,7 @@ mod trace {
         Lazy::new(|| env::var(ENV_COLLECTOR_API_KEY).ok());
 
     pub fn init_global_tracer() -> Result<(), SetGlobalDefaultError> {
-        let metadata = MetadataMap::from_headers({
+        let _metadata = MetadataMap::from_headers({
             let mut metadata = HeaderMap::new();
             if let Some(api_key) = &*COLLECTOR_API_KEY {
                 metadata.insert(COLLECTOR_API_KEY_HEADER.as_str(), api_key.parse().unwrap());
@@ -236,8 +236,9 @@ mod trace {
             .with_exporter(
                 opentelemetry_otlp::new_exporter()
                     .tonic()
-                    .with_endpoint(&*COLLECTOR_URL)
-                    .with_metadata(metadata),
+                    .with_endpoint(&*COLLECTOR_URL),
+                // TODO: wait for opentelemetry_otlp v0.20.0
+                // .with_metadata(metadata),
             )
             .with_trace_config(sdktrace::config().with_resource(Resource::new(vec![
                 KeyValue::new(resource::SERVICE_NAME, SERVICE_NAME.clone()),

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,11 +1,6 @@
 use base64::{engine::general_purpose, Engine as _};
-use deadpool_lapin::{Config, Pool, Runtime};
-use lapin::{options, types::FieldTable, ExchangeKind};
 use once_cell::sync::Lazy;
-use reool::RedisPool;
-use sqlx::postgres::{PgPool, PgPoolOptions};
 use std::env;
-use tokio::runtime::Handle;
 
 const DEFAULT_PORT: &str = "8000";
 const DEFAULT_ADDR: &str = "127.0.0.1";
@@ -13,19 +8,18 @@ const DEFAULT_TEMPLATES_PATH: &str = "/etc/rauth/smtp/templates/*.html";
 const DEFAULT_JWT_HEADER: &str = "authorization";
 const DEFAULT_TOTP_HEADER: &str = "x-totp-secret";
 const DEFAULT_TOKEN_TIMEOUT: u64 = 7200;
-const DEFAULT_POOL_SIZE: u32 = 10;
 const DEFAULT_TOTP_SECRET_LEN: usize = 32_usize;
+#[allow(dead_code)]
+const DEFAULT_POOL_SIZE: u32 = 10;
+#[allow(dead_code)]
+const DEFAULT_CONN_TIMEOUT: u32 = 100; //ms
 
 const ENV_SERVICE_PORT: &str = "SERVICE_PORT";
 const ENV_SERVICE_ADDR: &str = "SERVICE_ADDR";
-const ENV_POSTGRES_DSN: &str = "POSTGRES_DSN";
-const ENV_POSTGRES_POOL: &str = "POSTGRES_POOL";
 const ENV_JWT_SECRET: &str = "JWT_SECRET";
 const ENV_JWT_PUBLIC: &str = "JWT_PUBLIC";
 const ENV_JWT_HEADER: &str = "JWT_HEADER";
 const ENV_TOTP_HEADER: &str = "TOTP_HEADER";
-const ENV_REDIS_URL: &str = "REDIS_URL";
-const ENV_REDIS_POOL: &str = "REDIS_POOL";
 const ENV_TOKEN_TIMEOUT: &str = "TOKEN_TIMEOUT";
 const ENV_SMTP_TRANSPORT: &str = "SMTP_TRANSPORT";
 const ENV_SMTP_USERNAME: &str = "SMTP_USERNAME";
@@ -34,10 +28,6 @@ const ENV_SMTP_ISSUER: &str = "SMTP_ISSUER";
 const ENV_SMTP_TEMPLATES: &str = "SMTP_TEMPLATES";
 const ENV_SMTP_ORIGIN: &str = "SMTP_ORIGIN";
 const ENV_PWD_SUFIX: &str = "PWD_SUFIX";
-const ENV_RABBITMQ_USERS_EXCHANGE: &str = "RABBITMQ_USERS_EXCHANGE";
-const ENV_RABBITMQ_URL: &str = "RABBITMQ_URL";
-const ENV_RABBITMQ_POOL: &str = "RABBITMQ_POOL";
-const ENV_EVENT_ISSUER: &str = "EVENT_ISSUER";
 const ENV_TOTP_SECRET_LEN: &str = "TOTP_SECRET_LEN";
 const ENV_TOKEN_ISSUER: &str = "TOKEN_ISSUER";
 
@@ -93,83 +83,6 @@ pub static SMTP_TEMPLATES: Lazy<String> = Lazy::new(|| {
 pub static PWD_SUFIX: Lazy<String> =
     Lazy::new(|| env::var(ENV_PWD_SUFIX).expect("password sufix must be set"));
 
-pub static POSTGRES_POOL: Lazy<PgPool> = Lazy::new(|| {
-    futures::executor::block_on(async {
-        let postgres_dsn = env::var(ENV_POSTGRES_DSN).expect("postgres dns must be set");
-
-        let postgres_pool = env::var(ENV_POSTGRES_POOL)
-            .map(|pool_size| pool_size.parse().unwrap())
-            .unwrap_or(DEFAULT_POOL_SIZE);
-
-        PgPoolOptions::new()
-            .max_connections(postgres_pool)
-            .connect(&postgres_dsn)
-            .await
-            .unwrap()
-    })
-});
-
-pub static REDIS_POOL: Lazy<RedisPool> = Lazy::new(|| {
-    let redis_url: String = env::var(ENV_REDIS_URL).expect("redis url must be set");
-    let redis_pool: usize = env::var(ENV_REDIS_POOL)
-        .map(|pool_size| pool_size.parse().unwrap())
-        .unwrap_or_else(|_| DEFAULT_POOL_SIZE.try_into().unwrap());
-
-    RedisPool::builder()
-        .connect_to_node(redis_url)
-        .desired_pool_size(redis_pool)
-        .task_executor(Handle::current())
-        .finish_redis_rs()
-        .unwrap()
-});
-
-pub static RABBITMQ_USERS_EXCHANGE: Lazy<String> = Lazy::new(|| {
-    env::var(ENV_RABBITMQ_USERS_EXCHANGE).expect("rabbitmq users bus name must be set")
-});
-
-pub static RABBITMQ_POOL: Lazy<Pool> = Lazy::new(|| {
-    futures::executor::block_on(async {
-        let rabbitmq_url = env::var(ENV_RABBITMQ_URL).expect("rabbitmq url must be set");
-        let rabbitmq_pool = env::var(ENV_RABBITMQ_POOL)
-            .map(|pool_size| pool_size.parse().unwrap())
-            .unwrap_or_else(|_| DEFAULT_POOL_SIZE.try_into().unwrap());
-
-        let pool = Config {
-            url: Some(rabbitmq_url),
-            ..Default::default()
-        }
-        .builder(Some(Runtime::Tokio1))
-        .max_size(rabbitmq_pool)
-        .build()
-        .unwrap();
-
-        let channel = pool.get().await.unwrap().create_channel().await.unwrap();
-
-        let exchange_options = options::ExchangeDeclareOptions {
-            durable: true,
-            auto_delete: false,
-            internal: false,
-            nowait: false,
-            passive: false,
-        };
-
-        channel
-            .exchange_declare(
-                &RABBITMQ_USERS_EXCHANGE,
-                ExchangeKind::Fanout,
-                exchange_options,
-                FieldTable::default(),
-            )
-            .await
-            .unwrap();
-
-        pool
-    })
-});
-
-pub static EVENT_ISSUER: Lazy<String> =
-    Lazy::new(|| env::var(ENV_EVENT_ISSUER).expect("event issuer must be set"));
-
 pub static TOTP_SECRET_LEN: Lazy<usize> = Lazy::new(|| {
     env::var(ENV_TOTP_SECRET_LEN)
         .map(|len| len.parse().unwrap())
@@ -179,12 +92,168 @@ pub static TOTP_SECRET_LEN: Lazy<usize> = Lazy::new(|| {
 pub static TOKEN_ISSUER: Lazy<String> =
     Lazy::new(|| env::var(ENV_TOKEN_ISSUER).expect("token issuer must be set"));
 
+#[cfg(feature = "postgres")]
+pub use postgres::*;
+
+#[cfg(feature = "postgres")]
+mod postgres {
+    use once_cell::sync::Lazy;
+    use sqlx::{postgres::PgPoolOptions, PgPool};
+    use std::{env, time::Duration};
+
+    const ENV_POSTGRES_TIMEOUT: &str = "POSTGRES_TIMEOUT";
+    const ENV_POSTGRES_DSN: &str = "POSTGRES_DSN";
+    const ENV_POSTGRES_POOL: &str = "POSTGRES_POOL";
+
+    pub static POSTGRES_TIMEOUT: Lazy<Duration> = Lazy::new(|| {
+        Duration::from_millis(
+            env::var(ENV_POSTGRES_TIMEOUT)
+                .unwrap_or(super::DEFAULT_CONN_TIMEOUT.to_string())
+                .parse()
+                .expect("timeout must be an unsigned number of seconds"),
+        )
+    });
+
+    pub static POSTGRES_POOL: Lazy<PgPool> = Lazy::new(|| {
+        futures::executor::block_on(async {
+            let postgres_dsn = env::var(ENV_POSTGRES_DSN).expect("postgres dns must be set");
+
+            let postgres_pool = env::var(ENV_POSTGRES_POOL)
+                .map(|pool_size| pool_size.parse().unwrap())
+                .unwrap_or(super::DEFAULT_POOL_SIZE);
+
+            PgPoolOptions::new()
+                .max_connections(postgres_pool)
+                .acquire_timeout(*POSTGRES_TIMEOUT)
+                .connect(&postgres_dsn)
+                .await
+                .unwrap()
+        })
+    });
+}
+
+#[cfg(feature = "redis-cache")]
+pub use redis_cache::*;
+
+#[cfg(feature = "redis-cache")]
+mod redis_cache {
+    use once_cell::sync::Lazy;
+    use reool::{config::DefaultCommandTimeout, RedisPool};
+    use std::env;
+    use tokio::runtime::Handle;
+
+    const ENV_REDIS_TIMEOUT: &str = "REDIS_TIMEOUT";
+
+    const ENV_REDIS_URL: &str = "REDIS_URL";
+    const ENV_REDIS_POOL: &str = "REDIS_POOL";
+
+    pub static REDIS_TIMEOUT: Lazy<DefaultCommandTimeout> = Lazy::new(|| {
+        env::var(ENV_REDIS_TIMEOUT)
+            .unwrap_or(super::DEFAULT_CONN_TIMEOUT.to_string())
+            .parse()
+            .unwrap()
+    });
+
+    pub static REDIS_POOL: Lazy<RedisPool> = Lazy::new(|| {
+        let redis_url: String = env::var(ENV_REDIS_URL).expect("redis url must be set");
+        let redis_pool: usize = env::var(ENV_REDIS_POOL)
+            .map(|pool_size| pool_size.parse().unwrap())
+            .unwrap_or_else(|_| super::DEFAULT_POOL_SIZE.try_into().unwrap());
+
+        RedisPool::builder()
+            .connect_to_node(redis_url)
+            .desired_pool_size(redis_pool)
+            .task_executor(Handle::current())
+            .default_command_timeout(*REDIS_TIMEOUT)
+            .finish_redis_rs()
+            .unwrap()
+    });
+}
+
+#[cfg(feature = "rabbitmq")]
+pub use rabbitmq::*;
+
+#[cfg(feature = "rabbitmq")]
+mod rabbitmq {
+    use deadpool_lapin::{Config, Pool, Runtime, Timeouts};
+    use lapin::{options, types::FieldTable, ExchangeKind};
+    use once_cell::sync::Lazy;
+    use std::env;
+    use std::time::Duration;
+
+    const ENV_RABBITMQ_USERS_EXCHANGE: &str = "RABBITMQ_USERS_EXCHANGE";
+    const ENV_RABBITMQ_TIMEOUT: &str = "RABBITMQ_TIMEOUT";
+    const ENV_RABBITMQ_URL: &str = "RABBITMQ_URL";
+    const ENV_RABBITMQ_POOL: &str = "RABBITMQ_POOL";
+    const ENV_EVENT_ISSUER: &str = "EVENT_ISSUER";
+
+    pub static RABBITMQ_USERS_EXCHANGE: Lazy<String> = Lazy::new(|| {
+        env::var(ENV_RABBITMQ_USERS_EXCHANGE).expect("rabbitmq users bus name must be set")
+    });
+
+    pub static RABBITMQ_TIMEOUT: Lazy<Duration> = Lazy::new(|| {
+        Duration::from_millis(
+            env::var(ENV_RABBITMQ_TIMEOUT)
+                .unwrap_or(super::DEFAULT_CONN_TIMEOUT.to_string())
+                .parse()
+                .expect("timeout must be an unsigned number of seconds"),
+        )
+    });
+
+    pub static RABBITMQ_POOL: Lazy<Pool> = Lazy::new(|| {
+        futures::executor::block_on(async {
+            let rabbitmq_url = env::var(ENV_RABBITMQ_URL).expect("rabbitmq url must be set");
+            let rabbitmq_pool = env::var(ENV_RABBITMQ_POOL)
+                .map(|pool_size| pool_size.parse().unwrap())
+                .unwrap_or_else(|_| super::DEFAULT_POOL_SIZE.try_into().unwrap());
+
+            let pool = Config {
+                url: Some(rabbitmq_url),
+                ..Default::default()
+            }
+            .builder(Some(Runtime::Tokio1))
+            .max_size(rabbitmq_pool)
+            .timeouts(Timeouts {
+                wait: Some(*RABBITMQ_TIMEOUT),
+                create: Some(*RABBITMQ_TIMEOUT),
+                recycle: Some(*RABBITMQ_TIMEOUT),
+            })
+            .build()
+            .unwrap();
+
+            let channel = pool.get().await.unwrap().create_channel().await.unwrap();
+
+            let exchange_options = options::ExchangeDeclareOptions {
+                durable: true,
+                auto_delete: false,
+                internal: false,
+                nowait: false,
+                passive: false,
+            };
+
+            channel
+                .exchange_declare(
+                    &RABBITMQ_USERS_EXCHANGE,
+                    ExchangeKind::Fanout,
+                    exchange_options,
+                    FieldTable::default(),
+                )
+                .await
+                .unwrap();
+
+            pool
+        })
+    });
+
+    pub static EVENT_ISSUER: Lazy<String> =
+        Lazy::new(|| env::var(ENV_EVENT_ISSUER).expect("event issuer must be set"));
+}
+
 #[cfg(feature = "trace")]
 pub use trace::*;
 
 #[cfg(feature = "trace")]
 mod trace {
-    use actix_web::http::header::HeaderName;
     use once_cell::sync::Lazy;
     use opentelemetry_api::global;
     use opentelemetry_api::KeyValue;
@@ -194,8 +263,10 @@ mod trace {
     use std::env;
     use tonic::codegen::http::HeaderMap;
     use tonic::metadata::MetadataMap;
+    use tracing::metadata::LevelFilter;
     use tracing::subscriber::SetGlobalDefaultError;
     use tracing_subscriber::layer::SubscriberExt;
+    use tracing_subscriber::Layer;
     use tracing_subscriber::Registry;
 
     const KEY_VALUE_SEPARATOR: &str = "=";
@@ -227,7 +298,7 @@ mod trace {
             COLLECTOR_HEADERS.split(&*HEADERS_SEPARATOR).map(|split| {
                 let header: Vec<&str> = split.split(KEY_VALUE_SEPARATOR).collect();
                 (
-                    HeaderName::try_from(header[0]).expect("header name must be valid"),
+                    header[0].try_into().expect("header name must be valid"),
                     header[1].try_into().expect("header value must be valid"),
                 )
             }),
@@ -248,7 +319,12 @@ mod trace {
             .unwrap();
 
         let telemetry = tracing_opentelemetry::layer().with_tracer(tracer);
-        let subscriber = Registry::default().with(telemetry);
+        let stdout_log = tracing_subscriber::fmt::layer().pretty();
+
+        let subscriber = Registry::default()
+            .with(telemetry)
+            .with(stdout_log.with_filter(LevelFilter::INFO));
+
         tracing::subscriber::set_global_default(subscriber)
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,17 +2,16 @@ use base64::{engine::general_purpose, Engine as _};
 use once_cell::sync::Lazy;
 use std::env;
 
-const DEFAULT_PORT: &str = "8000";
-const DEFAULT_ADDR: &str = "127.0.0.1";
-const DEFAULT_TEMPLATES_PATH: &str = "/etc/rauth/smtp/templates/*.html";
-const DEFAULT_JWT_HEADER: &str = "authorization";
-const DEFAULT_TOTP_HEADER: &str = "x-totp-secret";
-const DEFAULT_TOKEN_TIMEOUT: u64 = 7200;
-const DEFAULT_TOTP_SECRET_LEN: usize = 32_usize;
+pub const DEFAULT_PORT: &str = "8000";
+pub const DEFAULT_ADDR: &str = "127.0.0.1";
+pub const DEFAULT_JWT_HEADER: &str = "authorization";
+pub const DEFAULT_TOTP_HEADER: &str = "x-totp-secret";
+pub const DEFAULT_TOKEN_TIMEOUT: u64 = 7200;
+pub const DEFAULT_TOTP_SECRET_LEN: usize = 32_usize;
 #[allow(dead_code)]
-const DEFAULT_POOL_SIZE: u32 = 10;
+pub const DEFAULT_POOL_SIZE: u32 = 10;
 #[allow(dead_code)]
-const DEFAULT_CONN_TIMEOUT: u32 = 100; //ms
+pub const DEFAULT_CONN_TIMEOUT: u32 = 100; //ms
 
 const ENV_SERVICE_PORT: &str = "SERVICE_PORT";
 const ENV_SERVICE_ADDR: &str = "SERVICE_ADDR";
@@ -21,12 +20,7 @@ const ENV_JWT_PUBLIC: &str = "JWT_PUBLIC";
 const ENV_JWT_HEADER: &str = "JWT_HEADER";
 const ENV_TOTP_HEADER: &str = "TOTP_HEADER";
 const ENV_TOKEN_TIMEOUT: &str = "TOKEN_TIMEOUT";
-const ENV_SMTP_TRANSPORT: &str = "SMTP_TRANSPORT";
-const ENV_SMTP_USERNAME: &str = "SMTP_USERNAME";
-const ENV_SMTP_PASSWORD: &str = "SMTP_PASSWORD";
-const ENV_SMTP_ISSUER: &str = "SMTP_ISSUER";
-const ENV_SMTP_TEMPLATES: &str = "SMTP_TEMPLATES";
-const ENV_SMTP_ORIGIN: &str = "SMTP_ORIGIN";
+
 const ENV_PWD_SUFIX: &str = "PWD_SUFIX";
 const ENV_TOTP_SECRET_LEN: &str = "TOTP_SECRET_LEN";
 const ENV_TOKEN_ISSUER: &str = "TOKEN_ISSUER";
@@ -61,25 +55,6 @@ pub static JWT_HEADER: Lazy<String> =
 pub static TOTP_HEADER: Lazy<String> =
     Lazy::new(|| env::var(ENV_TOTP_HEADER).unwrap_or_else(|_| DEFAULT_TOTP_HEADER.to_string()));
 
-pub static SMTP_TRANSPORT: Lazy<String> =
-    Lazy::new(|| env::var(ENV_SMTP_TRANSPORT).expect("smtp transport must be set"));
-
-pub static SMTP_USERNAME: Lazy<String> =
-    Lazy::new(|| env::var(ENV_SMTP_USERNAME).unwrap_or_default());
-
-pub static SMTP_PASSWORD: Lazy<String> =
-    Lazy::new(|| env::var(ENV_SMTP_PASSWORD).unwrap_or_default());
-
-pub static SMTP_ORIGIN: Lazy<String> =
-    Lazy::new(|| env::var(ENV_SMTP_ORIGIN).expect("smpt origin must be set"));
-
-pub static SMTP_ISSUER: Lazy<String> =
-    Lazy::new(|| env::var(ENV_SMTP_ISSUER).expect("smtp issuer must be set"));
-
-pub static SMTP_TEMPLATES: Lazy<String> = Lazy::new(|| {
-    env::var(ENV_SMTP_TEMPLATES).unwrap_or_else(|_| DEFAULT_TEMPLATES_PATH.to_string())
-});
-
 pub static PWD_SUFIX: Lazy<String> =
     Lazy::new(|| env::var(ENV_PWD_SUFIX).expect("password sufix must be set"));
 
@@ -91,244 +66,3 @@ pub static TOTP_SECRET_LEN: Lazy<usize> = Lazy::new(|| {
 
 pub static TOKEN_ISSUER: Lazy<String> =
     Lazy::new(|| env::var(ENV_TOKEN_ISSUER).expect("token issuer must be set"));
-
-#[cfg(feature = "postgres")]
-pub use postgres::*;
-
-#[cfg(feature = "postgres")]
-mod postgres {
-    use once_cell::sync::Lazy;
-    use sqlx::{postgres::PgPoolOptions, PgPool};
-    use std::{env, time::Duration};
-
-    const ENV_POSTGRES_TIMEOUT: &str = "POSTGRES_TIMEOUT";
-    const ENV_POSTGRES_DSN: &str = "POSTGRES_DSN";
-    const ENV_POSTGRES_POOL: &str = "POSTGRES_POOL";
-
-    pub static POSTGRES_TIMEOUT: Lazy<Duration> = Lazy::new(|| {
-        Duration::from_millis(
-            env::var(ENV_POSTGRES_TIMEOUT)
-                .unwrap_or(super::DEFAULT_CONN_TIMEOUT.to_string())
-                .parse()
-                .expect("timeout must be an unsigned number of seconds"),
-        )
-    });
-
-    pub static POSTGRES_POOL: Lazy<PgPool> = Lazy::new(|| {
-        futures::executor::block_on(async {
-            let postgres_dsn = env::var(ENV_POSTGRES_DSN).expect("postgres dns must be set");
-
-            let postgres_pool = env::var(ENV_POSTGRES_POOL)
-                .map(|pool_size| pool_size.parse().unwrap())
-                .unwrap_or(super::DEFAULT_POOL_SIZE);
-
-            PgPoolOptions::new()
-                .max_connections(postgres_pool)
-                .acquire_timeout(*POSTGRES_TIMEOUT)
-                .connect(&postgres_dsn)
-                .await
-                .unwrap()
-        })
-    });
-}
-
-#[cfg(feature = "redis-cache")]
-pub use redis_cache::*;
-
-#[cfg(feature = "redis-cache")]
-mod redis_cache {
-    use once_cell::sync::Lazy;
-    use reool::{config::DefaultCommandTimeout, RedisPool};
-    use std::env;
-    use tokio::runtime::Handle;
-
-    const ENV_REDIS_TIMEOUT: &str = "REDIS_TIMEOUT";
-
-    const ENV_REDIS_URL: &str = "REDIS_URL";
-    const ENV_REDIS_POOL: &str = "REDIS_POOL";
-
-    pub static REDIS_TIMEOUT: Lazy<DefaultCommandTimeout> = Lazy::new(|| {
-        env::var(ENV_REDIS_TIMEOUT)
-            .unwrap_or(super::DEFAULT_CONN_TIMEOUT.to_string())
-            .parse()
-            .unwrap()
-    });
-
-    pub static REDIS_POOL: Lazy<RedisPool> = Lazy::new(|| {
-        let redis_url: String = env::var(ENV_REDIS_URL).expect("redis url must be set");
-        let redis_pool: usize = env::var(ENV_REDIS_POOL)
-            .map(|pool_size| pool_size.parse().unwrap())
-            .unwrap_or_else(|_| super::DEFAULT_POOL_SIZE.try_into().unwrap());
-
-        RedisPool::builder()
-            .connect_to_node(redis_url)
-            .desired_pool_size(redis_pool)
-            .task_executor(Handle::current())
-            .default_command_timeout(*REDIS_TIMEOUT)
-            .finish_redis_rs()
-            .unwrap()
-    });
-}
-
-#[cfg(feature = "rabbitmq")]
-pub use rabbitmq::*;
-
-#[cfg(feature = "rabbitmq")]
-mod rabbitmq {
-    use deadpool_lapin::{Config, Pool, Runtime, Timeouts};
-    use lapin::{options, types::FieldTable, ExchangeKind};
-    use once_cell::sync::Lazy;
-    use std::env;
-    use std::time::Duration;
-
-    const ENV_RABBITMQ_USERS_EXCHANGE: &str = "RABBITMQ_USERS_EXCHANGE";
-    const ENV_RABBITMQ_TIMEOUT: &str = "RABBITMQ_TIMEOUT";
-    const ENV_RABBITMQ_URL: &str = "RABBITMQ_URL";
-    const ENV_RABBITMQ_POOL: &str = "RABBITMQ_POOL";
-    const ENV_EVENT_ISSUER: &str = "EVENT_ISSUER";
-
-    pub static RABBITMQ_USERS_EXCHANGE: Lazy<String> = Lazy::new(|| {
-        env::var(ENV_RABBITMQ_USERS_EXCHANGE).expect("rabbitmq users bus name must be set")
-    });
-
-    pub static RABBITMQ_TIMEOUT: Lazy<Duration> = Lazy::new(|| {
-        Duration::from_millis(
-            env::var(ENV_RABBITMQ_TIMEOUT)
-                .unwrap_or(super::DEFAULT_CONN_TIMEOUT.to_string())
-                .parse()
-                .expect("timeout must be an unsigned number of seconds"),
-        )
-    });
-
-    pub static RABBITMQ_POOL: Lazy<Pool> = Lazy::new(|| {
-        futures::executor::block_on(async {
-            let rabbitmq_url = env::var(ENV_RABBITMQ_URL).expect("rabbitmq url must be set");
-            let rabbitmq_pool = env::var(ENV_RABBITMQ_POOL)
-                .map(|pool_size| pool_size.parse().unwrap())
-                .unwrap_or_else(|_| super::DEFAULT_POOL_SIZE.try_into().unwrap());
-
-            let pool = Config {
-                url: Some(rabbitmq_url),
-                ..Default::default()
-            }
-            .builder(Some(Runtime::Tokio1))
-            .max_size(rabbitmq_pool)
-            .timeouts(Timeouts {
-                wait: Some(*RABBITMQ_TIMEOUT),
-                create: Some(*RABBITMQ_TIMEOUT),
-                recycle: Some(*RABBITMQ_TIMEOUT),
-            })
-            .build()
-            .unwrap();
-
-            let channel = pool.get().await.unwrap().create_channel().await.unwrap();
-
-            let exchange_options = options::ExchangeDeclareOptions {
-                durable: true,
-                auto_delete: false,
-                internal: false,
-                nowait: false,
-                passive: false,
-            };
-
-            channel
-                .exchange_declare(
-                    &RABBITMQ_USERS_EXCHANGE,
-                    ExchangeKind::Fanout,
-                    exchange_options,
-                    FieldTable::default(),
-                )
-                .await
-                .unwrap();
-
-            pool
-        })
-    });
-
-    pub static EVENT_ISSUER: Lazy<String> =
-        Lazy::new(|| env::var(ENV_EVENT_ISSUER).expect("event issuer must be set"));
-}
-
-#[cfg(feature = "trace")]
-pub use trace::*;
-
-#[cfg(feature = "trace")]
-mod trace {
-    use once_cell::sync::Lazy;
-    use opentelemetry_api::global;
-    use opentelemetry_api::KeyValue;
-    use opentelemetry_otlp::WithExportConfig;
-    use opentelemetry_sdk::{runtime, trace as sdktrace, Resource};
-    use opentelemetry_semantic_conventions::resource;
-    use std::env;
-    use tonic::codegen::http::HeaderMap;
-    use tonic::metadata::MetadataMap;
-    use tracing::metadata::LevelFilter;
-    use tracing::subscriber::SetGlobalDefaultError;
-    use tracing_subscriber::layer::SubscriberExt;
-    use tracing_subscriber::Layer;
-    use tracing_subscriber::Registry;
-
-    const KEY_VALUE_SEPARATOR: &str = "=";
-
-    const DEFAULT_SERVICE_NAME: &str = "rauth";
-    const DEFAULT_HEADERS_SEPARATOR: &str = ";";
-
-    const ENV_SERVICE_NAME: &str = "SERVICE_NAME";
-    const ENV_COLLECTOR_URL: &str = "COLLECTOR_URL";
-    const ENV_COLLECTOR_HEADERS: &str = "COLLECTOR_HEADERS";
-    const ENV_HEADERS_SEPARATOR: &str = "HEADERS_SEPARATOR";
-
-    static SERVICE_NAME: Lazy<String> = Lazy::new(|| {
-        env::var(ENV_SERVICE_NAME).unwrap_or_else(|_| DEFAULT_SERVICE_NAME.to_string())
-    });
-
-    static COLLECTOR_URL: Lazy<String> =
-        Lazy::new(|| env::var(ENV_COLLECTOR_URL).expect("collector url must be set"));
-
-    static COLLECTOR_HEADERS: Lazy<String> =
-        Lazy::new(|| env::var(ENV_COLLECTOR_HEADERS).unwrap_or_default());
-
-    static HEADERS_SEPARATOR: Lazy<String> = Lazy::new(|| {
-        env::var(ENV_HEADERS_SEPARATOR).unwrap_or(DEFAULT_HEADERS_SEPARATOR.to_string())
-    });
-
-    pub fn init_global_tracer() -> Result<(), SetGlobalDefaultError> {
-        let metadata = MetadataMap::from_headers(HeaderMap::from_iter(
-            COLLECTOR_HEADERS.split(&*HEADERS_SEPARATOR).map(|split| {
-                let header: Vec<&str> = split.split(KEY_VALUE_SEPARATOR).collect();
-                (
-                    header[0].try_into().expect("header name must be valid"),
-                    header[1].try_into().expect("header value must be valid"),
-                )
-            }),
-        ));
-
-        let tracer = opentelemetry_otlp::new_pipeline()
-            .tracing()
-            .with_exporter(
-                opentelemetry_otlp::new_exporter()
-                    .tonic()
-                    .with_endpoint(&*COLLECTOR_URL)
-                    .with_metadata(metadata),
-            )
-            .with_trace_config(sdktrace::config().with_resource(Resource::new(vec![
-                KeyValue::new(resource::SERVICE_NAME, SERVICE_NAME.clone()),
-            ])))
-            .install_batch(runtime::Tokio)
-            .unwrap();
-
-        let telemetry = tracing_opentelemetry::layer().with_tracer(tracer);
-        let stdout_log = tracing_subscriber::fmt::layer().pretty();
-
-        let subscriber = Registry::default()
-            .with(telemetry)
-            .with(stdout_log.with_filter(LevelFilter::INFO));
-
-        tracing::subscriber::set_global_default(subscriber)
-    }
-
-    pub fn shutdown_global_tracer() {
-        global::shutdown_tracer_provider()
-    }
-}

--- a/src/config.rs
+++ b/src/config.rs
@@ -222,7 +222,7 @@ mod trace {
         Lazy::new(|| env::var(ENV_COLLECTOR_API_KEY).ok());
 
     pub fn init_global_tracer() -> Result<(), SetGlobalDefaultError> {
-        let _metadata = MetadataMap::from_headers({
+        let metadata = MetadataMap::from_headers({
             let mut metadata = HeaderMap::new();
             if let Some(api_key) = &*COLLECTOR_API_KEY {
                 metadata.insert(COLLECTOR_API_KEY_HEADER.as_str(), api_key.parse().unwrap());
@@ -236,12 +236,11 @@ mod trace {
             .with_exporter(
                 opentelemetry_otlp::new_exporter()
                     .tonic()
-                    .with_endpoint(&*COLLECTOR_URL),
-                // TODO: wait for opentelemetry_otlp v0.20.0
-                // .with_metadata(metadata),s
+                    .with_endpoint(&*COLLECTOR_URL)
+                    .with_metadata(metadata),
             )
             .with_trace_config(sdktrace::config().with_resource(Resource::new(vec![
-                KeyValue::new(resource::SERVICE_NAME, SERVICE_NAME.clone()),
+                KeyValue::new(resource::SERVICE_NAME.into(), SERVICE_NAME.clone()),
             ])))
             .install_batch(runtime::Tokio)
             .unwrap();

--- a/src/config.rs
+++ b/src/config.rs
@@ -238,7 +238,7 @@ mod trace {
                     .tonic()
                     .with_endpoint(&*COLLECTOR_URL),
                 // TODO: wait for opentelemetry_otlp v0.20.0
-                // .with_metadata(metadata),
+                // .with_metadata(metadata),s
             )
             .with_trace_config(sdktrace::config().with_resource(Resource::new(vec![
                 KeyValue::new(resource::SERVICE_NAME, SERVICE_NAME.clone()),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,13 +3,21 @@ extern crate tracing;
 #[macro_use]
 extern crate serde;
 
-#[cfg(feature = "config")]
 pub mod config;
 pub mod metadata;
+#[cfg(feature = "postgres")]
+pub mod postgres;
+#[cfg(feature = "rabbitmq")]
+pub mod rabbitmq;
+#[cfg(feature = "redis-cache")]
+pub mod redis;
 pub mod secret;
 pub mod session;
+#[cfg(feature = "smtp")]
 pub mod smtp;
 pub mod token;
+#[cfg(feature = "tracer")]
+pub mod tracer;
 pub mod user;
 
 mod base64;
@@ -19,8 +27,6 @@ mod email;
 mod grpc;
 #[cfg(feature = "rest")]
 mod http;
-#[cfg(feature = "rabbitmq")]
-mod rabbitmq;
 mod regex;
 mod result;
 mod time;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@ mod email;
 mod grpc;
 #[cfg(feature = "rest")]
 mod http;
+#[cfg(feature = "rabbitmq")]
 mod rabbitmq;
 mod regex;
 mod result;

--- a/src/postgres.rs
+++ b/src/postgres.rs
@@ -1,0 +1,34 @@
+use crate::config;
+use once_cell::sync::Lazy;
+use sqlx::{postgres::PgPoolOptions, PgPool};
+use std::{env, time::Duration};
+
+const ENV_POSTGRES_TIMEOUT: &str = "POSTGRES_TIMEOUT";
+const ENV_POSTGRES_DSN: &str = "POSTGRES_DSN";
+const ENV_POSTGRES_POOL: &str = "POSTGRES_POOL";
+
+pub static POSTGRES_TIMEOUT: Lazy<Duration> = Lazy::new(|| {
+    Duration::from_millis(
+        env::var(ENV_POSTGRES_TIMEOUT)
+            .unwrap_or(config::DEFAULT_CONN_TIMEOUT.to_string())
+            .parse()
+            .expect("timeout must be an unsigned number of seconds"),
+    )
+});
+
+pub static POSTGRES_POOL: Lazy<PgPool> = Lazy::new(|| {
+    futures::executor::block_on(async {
+        let postgres_dsn = env::var(ENV_POSTGRES_DSN).expect("postgres dns must be set");
+
+        let postgres_pool = env::var(ENV_POSTGRES_POOL)
+            .map(|pool_size| pool_size.parse().unwrap())
+            .unwrap_or(config::DEFAULT_POOL_SIZE);
+
+        PgPoolOptions::new()
+            .max_connections(postgres_pool)
+            .acquire_timeout(*POSTGRES_TIMEOUT)
+            .connect(&postgres_dsn)
+            .await
+            .unwrap()
+    })
+});

--- a/src/rabbitmq.rs
+++ b/src/rabbitmq.rs
@@ -1,6 +1,79 @@
 //! RabbitMQ utilities for managing events handlering and emitions.
 
+use crate::config;
+use deadpool_lapin::{Config, Pool, Runtime, Timeouts};
+use lapin::{options, types::FieldTable, ExchangeKind};
+use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
+use std::env;
+use std::time::Duration;
+
+const ENV_RABBITMQ_USERS_EXCHANGE: &str = "RABBITMQ_USERS_EXCHANGE";
+const ENV_RABBITMQ_TIMEOUT: &str = "RABBITMQ_TIMEOUT";
+const ENV_RABBITMQ_URL: &str = "RABBITMQ_URL";
+const ENV_RABBITMQ_POOL: &str = "RABBITMQ_POOL";
+const ENV_EVENT_ISSUER: &str = "EVENT_ISSUER";
+
+pub static RABBITMQ_USERS_EXCHANGE: Lazy<String> = Lazy::new(|| {
+    env::var(ENV_RABBITMQ_USERS_EXCHANGE).expect("rabbitmq users bus name must be set")
+});
+
+pub static RABBITMQ_TIMEOUT: Lazy<Duration> = Lazy::new(|| {
+    Duration::from_millis(
+        env::var(ENV_RABBITMQ_TIMEOUT)
+            .unwrap_or(config::DEFAULT_CONN_TIMEOUT.to_string())
+            .parse()
+            .expect("timeout must be an unsigned number of seconds"),
+    )
+});
+
+pub static RABBITMQ_POOL: Lazy<Pool> = Lazy::new(|| {
+    futures::executor::block_on(async {
+        let rabbitmq_url = env::var(ENV_RABBITMQ_URL).expect("rabbitmq url must be set");
+        let rabbitmq_pool = env::var(ENV_RABBITMQ_POOL)
+            .map(|pool_size| pool_size.parse().unwrap())
+            .unwrap_or_else(|_| config::DEFAULT_POOL_SIZE.try_into().unwrap());
+
+        let pool = Config {
+            url: Some(rabbitmq_url),
+            ..Default::default()
+        }
+        .builder(Some(Runtime::Tokio1))
+        .max_size(rabbitmq_pool)
+        .timeouts(Timeouts {
+            wait: Some(*RABBITMQ_TIMEOUT),
+            create: Some(*RABBITMQ_TIMEOUT),
+            recycle: Some(*RABBITMQ_TIMEOUT),
+        })
+        .build()
+        .unwrap();
+
+        let channel = pool.get().await.unwrap().create_channel().await.unwrap();
+
+        let exchange_options = options::ExchangeDeclareOptions {
+            durable: true,
+            auto_delete: false,
+            internal: false,
+            nowait: false,
+            passive: false,
+        };
+
+        channel
+            .exchange_declare(
+                &RABBITMQ_USERS_EXCHANGE,
+                ExchangeKind::Fanout,
+                exchange_options,
+                FieldTable::default(),
+            )
+            .await
+            .unwrap();
+
+        pool
+    })
+});
+
+pub static EVENT_ISSUER: Lazy<String> =
+    Lazy::new(|| env::var(ENV_EVENT_ISSUER).expect("event issuer must be set"));
 
 /// Represents all the possible kind of events that may be handled or emited.
 #[derive(Serialize, Deserialize)]

--- a/src/redis.rs
+++ b/src/redis.rs
@@ -1,0 +1,31 @@
+use crate::config;
+use once_cell::sync::Lazy;
+use reool::{config::DefaultCommandTimeout, RedisPool};
+use std::env;
+use tokio::runtime::Handle;
+
+const ENV_REDIS_TIMEOUT: &str = "REDIS_TIMEOUT";
+const ENV_REDIS_URL: &str = "REDIS_URL";
+const ENV_REDIS_POOL: &str = "REDIS_POOL";
+
+pub static REDIS_TIMEOUT: Lazy<DefaultCommandTimeout> = Lazy::new(|| {
+    env::var(ENV_REDIS_TIMEOUT)
+        .unwrap_or(config::DEFAULT_CONN_TIMEOUT.to_string())
+        .parse()
+        .unwrap()
+});
+
+pub static REDIS_POOL: Lazy<RedisPool> = Lazy::new(|| {
+    let redis_url: String = env::var(ENV_REDIS_URL).expect("redis url must be set");
+    let redis_pool: usize = env::var(ENV_REDIS_POOL)
+        .map(|pool_size| pool_size.parse().unwrap())
+        .unwrap_or_else(|_| config::DEFAULT_POOL_SIZE.try_into().unwrap());
+
+    RedisPool::builder()
+        .connect_to_node(redis_url)
+        .desired_pool_size(redis_pool)
+        .task_executor(Handle::current())
+        .default_command_timeout(*REDIS_TIMEOUT)
+        .finish_redis_rs()
+        .unwrap()
+});

--- a/src/secret/application.rs
+++ b/src/secret/application.rs
@@ -1,11 +1,11 @@
-use super::domain::Secret;
+use super::domain::{Secret, SecretKind};
 use crate::result::Result;
 use async_trait::async_trait;
 
 #[async_trait]
 pub trait SecretRepository {
     async fn find(&self, id: i32) -> Result<Secret>;
-    async fn find_by_user_and_name(&self, user: i32, name: &str) -> Result<Secret>;
+    async fn find_by_user_and_kind(&self, user: i32, kind: SecretKind) -> Result<Secret>;
     async fn create(&self, secret: &mut Secret) -> Result<()>;
     async fn save(&self, secret: &Secret) -> Result<()>;
     async fn delete(&self, secret: &Secret) -> Result<()>;
@@ -16,11 +16,12 @@ pub mod tests {
     use super::super::domain::{tests::new_secret, Secret};
     use super::SecretRepository;
     use crate::result::Result;
+    use crate::secret::domain::SecretKind;
     use async_trait::async_trait;
 
     type MockFnFind = Option<fn(this: &SecretRepositoryMock, id: i32) -> Result<Secret>>;
-    type MockFnFindByUserAndName =
-        Option<fn(this: &SecretRepositoryMock, user: i32, name: &str) -> Result<Secret>>;
+    type MockFnFindByUserAndKind =
+        Option<fn(this: &SecretRepositoryMock, user: i32, kind: SecretKind) -> Result<Secret>>;
     type MockFnCreate = Option<fn(this: &SecretRepositoryMock, secret: &mut Secret) -> Result<()>>;
     type MockFnSave = Option<fn(this: &SecretRepositoryMock, secret: &Secret) -> Result<()>>;
     type MockFnDelete = Option<fn(this: &SecretRepositoryMock, secret: &Secret) -> Result<()>>;
@@ -28,7 +29,7 @@ pub mod tests {
     #[derive(Default)]
     pub struct SecretRepositoryMock {
         pub fn_find: MockFnFind,
-        pub fn_find_by_user_and_name: MockFnFindByUserAndName,
+        pub fn_find_by_user_and_kind: MockFnFindByUserAndKind,
         pub fn_create: MockFnCreate,
         pub fn_save: MockFnSave,
         pub fn_delete: MockFnDelete,
@@ -45,16 +46,14 @@ pub mod tests {
             Ok(new_secret())
         }
 
-        #[instrument(skip(self))]
-        async fn find_by_user_and_name(&self, user: i32, name: &str) -> Result<Secret> {
-            if let Some(f) = self.fn_find_by_user_and_name {
-                return f(self, user, name);
+        async fn find_by_user_and_kind(&self, user: i32, kind: SecretKind) -> Result<Secret> {
+            if let Some(f) = self.fn_find_by_user_and_kind {
+                return f(self, user, kind);
             }
 
             Ok(new_secret())
         }
 
-        #[instrument(skip(self))]
         async fn create(&self, secret: &mut Secret) -> Result<()> {
             if let Some(f) = self.fn_create {
                 return f(self, secret);
@@ -63,7 +62,6 @@ pub mod tests {
             Ok(())
         }
 
-        #[instrument(skip(self))]
         async fn save(&self, secret: &Secret) -> Result<()> {
             if let Some(f) = self.fn_save {
                 return f(self, secret);
@@ -72,7 +70,6 @@ pub mod tests {
             Ok(())
         }
 
-        #[instrument(skip(self))]
         async fn delete(&self, secret: &Secret) -> Result<()> {
             if let Some(f) = self.fn_delete {
                 return f(self, secret);

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -1,5 +1,5 @@
 pub mod application;
-#[cfg(all(feature = "grpc", feature = "postgres"))]
+#[cfg(feature = "grpc")]
 pub mod grpc;
-#[cfg(all(feature = "rest", feature = "postgres"))]
+#[cfg(feature = "rest")]
 pub mod rest;

--- a/src/smtp.rs
+++ b/src/smtp.rs
@@ -202,32 +202,3 @@ impl<'a> user_app::Mailer for Smtp<'a> {
         self.send_email(email, self.reset_subject, body)
     }
 }
-
-#[cfg(test)]
-pub mod tests {
-    use crate::result::{Error, Result};
-    use crate::user::application::Mailer;
-
-    #[derive(Default)]
-    pub struct MailerMock {
-        pub force_fail: bool,
-    }
-
-    impl Mailer for MailerMock {
-        fn send_verification_signup_email(&self, _: &str, _: &str) -> Result<()> {
-            if self.force_fail {
-                return Err(Error::Unknown);
-            }
-
-            Ok(())
-        }
-
-        fn send_verification_reset_email(&self, _: &str, _: &str) -> Result<()> {
-            if self.force_fail {
-                return Err(Error::Unknown);
-            }
-
-            Ok(())
-        }
-    }
-}

--- a/src/token/application.rs
+++ b/src/token/application.rs
@@ -155,18 +155,21 @@ pub mod tests {
     };
     use async_trait::async_trait;
     use base64::{engine::general_purpose, Engine as _};
-    use lazy_static::lazy_static;
+    use once_cell::sync::Lazy;
     use std::sync::Arc;
     use std::time::{Duration, SystemTime};
 
-    lazy_static! {
-        pub static ref PRIVATE_KEY: Vec<u8> = general_purpose::STANDARD.decode(
+    pub static PRIVATE_KEY: Lazy<Vec<u8>> = Lazy::new(|| {
+        general_purpose::STANDARD.decode(
             b"LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCk1JR0hBZ0VBTUJNR0J5cUdTTTQ5QWdFR0NDcUdTTTQ5QXdFSEJHMHdhd0lCQVFRZy9JMGJTbVZxL1BBN2FhRHgKN1FFSGdoTGxCVS9NcWFWMUJab3ZhM2Y5aHJxaFJBTkNBQVJXZVcwd3MydmlnWi96SzRXcGk3Rm1mK0VPb3FybQpmUlIrZjF2azZ5dnBGd0gzZllkMlllNXl4b3ZsaTROK1ZNNlRXVFErTmVFc2ZmTWY2TkFBMloxbQotLS0tLUVORCBQUklWQVRFIEtFWS0tLS0tCg=="
-        ).unwrap();
-        pub static ref PUBLIC_KEY: Vec<u8> = general_purpose::STANDARD.decode(
+        ).unwrap()
+    });
+
+    pub static PUBLIC_KEY: Lazy<Vec<u8>> = Lazy::new(|| {
+        general_purpose::STANDARD.decode(
             b"LS0tLS1CRUdJTiBQVUJMSUMgS0VZLS0tLS0KTUZrd0V3WUhLb1pJemowQ0FRWUlLb1pJemowREFRY0RRZ0FFVm5sdE1MTnI0b0dmOHl1RnFZdXhabi9oRHFLcQo1bjBVZm45YjVPc3I2UmNCOTMySGRtSHVjc2FMNVl1RGZsVE9rMWswUGpYaExIM3pIK2pRQU5tZFpnPT0KLS0tLS1FTkQgUFVCTElDIEtFWS0tLS0tCg=="
-        ).unwrap();
-    }
+        ).unwrap()
+    });
 
     type MockFnFind = Option<fn(this: &TokenRepositoryMock, key: &str) -> Result<String>>;
     type MockFnSave = Option<

--- a/src/tracer.rs
+++ b/src/tracer.rs
@@ -1,0 +1,102 @@
+use once_cell::sync::Lazy;
+use opentelemetry_api::global;
+use opentelemetry_api::KeyValue;
+use opentelemetry_otlp::WithExportConfig;
+use opentelemetry_sdk::{runtime, trace as sdktrace, Resource};
+use opentelemetry_semantic_conventions::resource;
+use std::env;
+use tonic::codegen::http::HeaderMap;
+use tonic::metadata::MetadataMap;
+use tracing::metadata::LevelFilter;
+use tracing::subscriber::SetGlobalDefaultError;
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::Layer;
+use tracing_subscriber::Registry;
+
+const KEY_VALUE_SEPARATOR: &str = "=";
+
+const DEFAULT_SERVICE_NAME: &str = "rauth";
+const DEFAULT_HEADERS_SEPARATOR: &str = ";";
+
+const ENV_SERVICE_NAME: &str = "SERVICE_NAME";
+const ENV_COLLECTOR_URL: &str = "COLLECTOR_URL";
+const ENV_COLLECTOR_HEADERS: &str = "COLLECTOR_HEADERS";
+const ENV_HEADERS_SEPARATOR: &str = "HEADERS_SEPARATOR";
+
+static SERVICE_NAME: Lazy<String> =
+    Lazy::new(|| env::var(ENV_SERVICE_NAME).unwrap_or_else(|_| DEFAULT_SERVICE_NAME.to_string()));
+
+static COLLECTOR_URL: Lazy<Option<String>> = Lazy::new(|| match env::var(ENV_COLLECTOR_URL) {
+    Ok(url) => Some(url),
+    Err(err) => {
+        error!(
+            error = err.to_string(),
+            "reading collector url from environment variables"
+        );
+
+        None
+    }
+});
+
+static COLLECTOR_HEADERS: Lazy<String> =
+    Lazy::new(|| env::var(ENV_COLLECTOR_HEADERS).unwrap_or_default());
+
+static HEADERS_SEPARATOR: Lazy<String> =
+    Lazy::new(|| env::var(ENV_HEADERS_SEPARATOR).unwrap_or(DEFAULT_HEADERS_SEPARATOR.to_string()));
+
+fn init_default() -> Result<(), SetGlobalDefaultError> {
+    let stdout_log = tracing_subscriber::fmt::layer().pretty();
+    let subscriber = Registry::default().with(stdout_log.with_filter(LevelFilter::INFO));
+
+    tracing::subscriber::set_global_default(subscriber)
+}
+
+fn init_with_collector(collector_url: &str) -> Result<(), SetGlobalDefaultError> {
+    let metadata = COLLECTOR_HEADERS
+        .is_empty()
+        .then_some(MetadataMap::default())
+        .unwrap_or_else(|| {
+            MetadataMap::from_headers(HeaderMap::from_iter(
+                COLLECTOR_HEADERS.split(&*HEADERS_SEPARATOR).map(|split| {
+                    let header: Vec<&str> = split.split(KEY_VALUE_SEPARATOR).collect();
+                    (header[0].try_into().unwrap(), header[1].try_into().unwrap())
+                }),
+            ))
+        });
+
+    let tracer =
+        opentelemetry_otlp::new_pipeline()
+            .tracing()
+            .with_exporter(
+                opentelemetry_otlp::new_exporter()
+                    .tonic()
+                    .with_endpoint(collector_url)
+                    .with_metadata(metadata),
+            )
+            .with_trace_config(sdktrace::config().with_resource(Resource::new(vec![
+                KeyValue::new(resource::SERVICE_NAME, SERVICE_NAME.clone()),
+            ])))
+            .install_batch(runtime::Tokio)
+            .unwrap();
+
+    let telemetry = tracing_opentelemetry::layer().with_tracer(tracer);
+    let stdout_log = tracing_subscriber::fmt::layer().pretty();
+
+    let subscriber = Registry::default()
+        .with(telemetry)
+        .with(stdout_log.with_filter(LevelFilter::INFO));
+
+    tracing::subscriber::set_global_default(subscriber)
+}
+
+pub fn init() -> Result<(), SetGlobalDefaultError> {
+    if let Some(collector_url) = &*COLLECTOR_URL {
+        init_with_collector(collector_url)
+    } else {
+        init_default()
+    }
+}
+
+pub fn shutdown() {
+    global::shutdown_tracer_provider()
+}

--- a/src/user/application.rs
+++ b/src/user/application.rs
@@ -370,7 +370,7 @@ impl<'a, U: UserRepository, E: SecretRepository, T: TokenRepository, B: EventBus
 pub mod tests {
     use super::super::domain::tests::{TEST_DEFAULT_USER_EMAIL, TEST_DEFAULT_USER_PASSWORD};
     use super::super::domain::{tests::new_user_custom, User};
-    use super::{EventBus, UserApplication, UserRepository};
+    use super::{EventBus, Mailer, UserApplication, UserRepository};
     use crate::secret::domain::SecretKind;
     use crate::secret::{
         application::tests::SecretRepositoryMock,
@@ -379,7 +379,6 @@ pub mod tests {
             Secret,
         },
     };
-    use crate::smtp::tests::MailerMock;
     use crate::token::application::tests::{new_token_application, PRIVATE_KEY, PUBLIC_KEY};
     use crate::token::{
         application::tests::TokenRepositoryMock,
@@ -480,6 +479,29 @@ pub mod tests {
         async fn emit_user_created(&self, user: &User) -> Result<()> {
             if let Some(f) = self.fn_emit_user_created {
                 return f(self, user);
+            }
+
+            Ok(())
+        }
+    }
+
+    #[derive(Default)]
+    pub struct MailerMock {
+        pub force_fail: bool,
+    }
+
+    impl Mailer for MailerMock {
+        fn send_verification_signup_email(&self, _: &str, _: &str) -> Result<()> {
+            if self.force_fail {
+                return Err(Error::Unknown);
+            }
+
+            Ok(())
+        }
+
+        fn send_verification_reset_email(&self, _: &str, _: &str) -> Result<()> {
+            if self.force_fail {
+                return Err(Error::Unknown);
             }
 
             Ok(())

--- a/src/user/domain.rs
+++ b/src/user/domain.rs
@@ -18,12 +18,12 @@ pub struct User {
 impl User {
     pub fn new(email: &str, password: &str) -> Result<Self> {
         regex::match_regex(regex::EMAIL, email).map_err(|err| {
-            warn!(error = err.to_string(), "validating email's format",);
+            warn!(error = err.to_string(), "validating email format",);
             Error::InvalidFormat
         })?;
 
         regex::match_regex(regex::BASE64, password).map_err(|err| {
-            warn!(error = err.to_string(), "validating password's format",);
+            warn!(error = err.to_string(), "validating password format",);
             Error::InvalidFormat
         })?;
 


### PR DESCRIPTION
The main purpose of this PR is to implement the tracing feature described in #123 . This allows any client to export traces of the application to the desired collector. Traces are sent using the [OTLP](https://opentelemetry.io/docs/specs/otel/protocol/) and gRPC.

Besides, this PR also includes a bunch of refactors. One, and probably the most important one, is the spread of the definition of environment variables to their corresponding file (for example: Postgres env variables are now declared in the `postgres.rs` file instead of `config.rs`). This is related to the reorganization of the __crate's features__: new features have been added in order to keep the core as lightweight as possible. 

Last but not least, Secrets no longer have an arbitrary name when stored in the database. An enumerator `SecretKind` is used instead. This change also required the `sql` files from `migrations` to be updated.